### PR TITLE
In `collectContentPre` hook, check that `context.cls` before using it.

### DIFF
--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -4,21 +4,22 @@ var collectContentPre = function(hook, context){
   var state = context.state; 
   var lineAttributes = state.lineAttributes
 
-  var tagIndex = cls.indexOf("tasklist-not-done");
-  if(tagIndex === 0){
-    lineAttributes['tasklist-not-done'] = tags[tagIndex];
-  }
+  if(cls !== null) {
+    var tagIndex = cls.indexOf("tasklist-not-done");
+    if(tagIndex === 0){
+      lineAttributes['tasklist-not-done'] = tags[tagIndex];
+    }
 
-  var tagIndex = cls.indexOf("tasklist-done");
-  if(tagIndex !== -1){
-    lineAttributes['tasklist-done'] = 'tasklist-done';
-  }
+    var tagIndex = cls.indexOf("tasklist-done");
+    if(tagIndex !== -1){
+      lineAttributes['tasklist-done'] = 'tasklist-done';
+    }
 
-  if(tname === "div" || tname === "p"){
-    delete lineAttributes['tasklist-done'];
-    delete lineAttributes['tasklist-not-done'];
+    if(tname === "div" || tname === "p"){
+      delete lineAttributes['tasklist-done'];
+      delete lineAttributes['tasklist-not-done'];
+    }
   }
-
 };
 
 var collectContentPost = function(hook, context){


### PR DESCRIPTION
Since 58ab17bf9e21cd5c5266f3f7c1de80eedc1821dd, `context.cls` could be
`null`. When pasting formated content on a pad, it provoques a fatal
error:

> [Error] TypeError: null is not an object (evaluating 'cls.indexOf')

This issue was reported here: ether/etherpad-lite#2760
